### PR TITLE
web-145a-CorrectSocialSignIn

### DIFF
--- a/src/authentication/Landning/index.tsx
+++ b/src/authentication/Landning/index.tsx
@@ -14,11 +14,13 @@ export default function LandingPage() {
 
   async function getSocialSignIn(provider: any) {
     const signInData = socialSignIn(provider);
-    if (signInData) handleSupabaseSetup(signInData, setActiveSession);
+    if (signInData) {
+      handleSupabaseSetup(signInData, setActiveSession);
+    }
   }
 
   async function handleSupabaseSetup(sessionToken: any, setActiveSession: React.Dispatch<React.SetStateAction<ActiveSession | null>>) {
-    if (sessionToken) {
+    if (sessionToken.user) {
       await localStorage.setItem('token', JSON.stringify(sessionToken));
       if (sessionToken.session) {
         setActiveSession(sessionToken.session);


### PR DESCRIPTION
Updated handleSupabaseSetup to check for session token to have .user before proceeding

This prevents the map from being show prematurely when using social sign ins
