### PR TITLE
fix: Button icon on google map

### DIFF
--- a/src/reusables/roundButton/style.module.scss
+++ b/src/reusables/roundButton/style.module.scss
@@ -20,7 +20,7 @@
 }
 
 .icon {
-	// display: contents;
+	display: contents;
 
 	svg,
 	img {


### PR DESCRIPTION
from 
![image](https://github.com/user-attachments/assets/bb824083-4026-4379-bf26-e9f8afe4afa6)

to
![image](https://github.com/user-attachments/assets/3f9a2dcd-00ba-4cd6-b709-43cac3c28785)
